### PR TITLE
フロントの修正およびlintの修正

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,33 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "overrides": [
+        {
+            "env": {
+                "node": true
+            },
+            "files": [
+                ".eslintrc.{js,cjs}"
+            ],
+            "parserOptions": {
+                "sourceType": "script"
+            }
+        }
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,14 +1,15 @@
 <!doctype html>
-<html lang="en">
+<html lang="jp">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + TS</title>
+      <link rel="stylesheet" href="src/style.css" />
+    <title>ドコナンYO</title>
   </head>
   <body>
 
-  <div id="app"><canvas id="c" style="width: 100%; height: 100%;"></canvas></div>
+  <div id="app"><canvas id="c"></canvas></div>
 
     <script type="module" src="/src/main.ts">
     </script>

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview",
     "lint:check": "eslint --ext .js,.ts .",
     "lint:fix": "eslint --ext .js,.ts . --fix",
-    "format:check": "prettier --check **/*.{ts,js}",
-    "format:fix": "prettier --write **/*.{ts,js}"
+    "format:check": "prettier --check '**/*.{ts,js}'",
+    "format:fix": "prettier --write '**/*.{ts,js}'"
   },
   "devDependencies": {
     "@types/three": "^0.161.2",

--- a/src/style.css
+++ b/src/style.css
@@ -1,1 +1,7 @@
-
+html,body,#c,div{
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+}


### PR DESCRIPTION
## やったこと
- スマホでもwebでも見た目がよくなるようにcssを書き換えた.
- prettierを実行するとパターンマッチングがうまくいっていなかったのでpre-commitで必ず引っ掛かるようになっていたので修正した.
- html langがenのままだったのでjpに変更した.
- meta情報のtitleの変更(ブラウザのタブのタイトルが変更される)
## 見てほしいところ
- web、スマホ双方での見た目
- package.jsonのscriptsの訂正部分（できればformat:checkなどをためして欲しい）
### 実行前にやってほしいこと

## Others